### PR TITLE
jsonobj: fix GoDoc list formatting

### DIFF
--- a/jsonobj/retain.go
+++ b/jsonobj/retain.go
@@ -90,10 +90,10 @@ func MustRetainable(obj interface {
 }
 
 // Retainable checks that the provided type is supported for Retain marshalling
-// by checking for:
-// * The type is a struct pointer (for `UnmarshalJSON` to work correctly).
-// * The type has no duplicate JSON field names.
-// * The type has no unsupported json tags.
+// by checking that:
+//  * The type is a struct pointer (for `UnmarshalJSON` to work correctly).
+//  * The type has no duplicate JSON field names.
+//  * The type has no unsupported json tags.
 func Retainable(obj interface {
 	json.Marshaler
 	json.Unmarshaler


### PR DESCRIPTION
The Markdown-like formatting that GoDoc supports nowadays requires
lists to be indented (like code blocks).
